### PR TITLE
Add Seaborn by default

### DIFF
--- a/jupyterlab/requirements.txt
+++ b/jupyterlab/requirements.txt
@@ -16,4 +16,5 @@ pandas==1.2.1
 psycopg2==2.8.6
 python-dateutil==2.8.1
 scrapy==2.4.1
+seaborn==0.11.1
 SQLAlchemy==1.3.23


### PR DESCRIPTION
# Proposed Changes

Adds Seaborn by default, to support the updated Jupyter notebooks from Home Assistant
