### PR TITLE
Allow us to run as root

### DIFF
--- a/jupyterlab/rootfs/etc/services.d/jupyter/run
+++ b/jupyterlab/rootfs/etc/services.d/jupyter/run
@@ -35,4 +35,4 @@ fi
 cd /config/notebooks || bashio::exit.nok 'Failed changing working directory'
 
 # Run Juypter Notebook server
-exec jupyter lab "${options[@]}"
+exec jupyter lab --allow-root "${options[@]}"


### PR DESCRIPTION
Fixes #319

# Proposed Changes

There's an issue w/ running as root. I'm *guessing* the configuration option in itself isn't enough any more to allow for it. Adding a flag to the command line does resolve the issue—and the container does start. 

HTH.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
