### PR TITLE
Add pip updates to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,8 @@ updates:
     schedule:
       interval: daily
       time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/jupyterlab"
+    schedule:
+      interval: daily
+      time: "06:00"


### PR DESCRIPTION
# Proposed Changes

Allows dependabot to create PRs for pip package updates.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
